### PR TITLE
docs: fix README.md inaccuracies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 A Home Assistant custom integration that connects to Firefly Cloud (school learning platform) to display children's school schedules and upcoming tasks on your smart home dashboard.
 
+## todo:
+
+* figure out if we can / should we try and ping phone showing the widgets to update at the start of every class?
+
 ## Features
 
 - **Upcoming Tasks**: Monitor homework, projects, and assignments with due dates
@@ -43,6 +47,7 @@ A Home Assistant custom integration that connects to Firefly Cloud (school learn
 
 After setup, you can configure additional options by clicking "Configure" on the integration:
 
+- **Task Lookahead Days**: Number of days ahead to look for upcoming tasks (1-30 days). Default: 7 days.
 - **Show Class Times**: Display time prefixes for current and next class sensors (e.g., "09.00-10.00: Mathematics" instead of just "Mathematics"). Default: disabled.
 
 ## Entities Created
@@ -131,7 +136,7 @@ The dev container provides multiple approaches for manual testing:
 - Integration pre-installed and symlinked
 - Add Firefly Cloud through Settings > Devices & Services
 - Complete authentication flow with real Firefly credentials
-- Verify four sensors are created for each child
+- Verify five sensors are created for each child
 - Debug logging enabled for troubleshooting
 
 **3. VS Code Testing Features**


### PR DESCRIPTION
## Summary
- Fix sensor count: Changed from "four sensors" to "five sensors" to accurately reflect all sensor types created per child
- Add missing documentation for **Task Lookahead Days** configuration option (1-30 days, default 7)

## Changes
- Updated manual testing section to reference five sensors instead of four
- Added Task Lookahead Days to Configuration Options section with proper description

🤖 Generated with [Claude Code](https://claude.com/claude-code)