### PR TITLE
ci: re-enable hacs check for brands now icons have been merged

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,6 @@ jobs:
         uses: hacs/action@main
         with:
           category: integration
-          ignore: brands # Ignore brands check as we are waiting for https://github.com/home-assistant/brands/pull/8080 to be merged
 
       - name: Hassfest validation
         uses: home-assistant/actions/hassfest@master


### PR DESCRIPTION
Now that https://github.com/home-assistant/brands/pull/8080 has merged, we can re-enable the check