### PR TITLE
fix: dont prefix sensors with school name

### DIFF
--- a/custom_components/firefly_cloud/calendar.py
+++ b/custom_components/firefly_cloud/calendar.py
@@ -57,8 +57,7 @@ class FireflyCalendar(FireflyBaseEntity, CalendarEntity):
         child_guid: str,
     ) -> None:
         """Initialize the calendar."""
-        school_name = config_entry.data.get(CONF_SCHOOL_NAME, "firefly")
-        base_name = f"{school_name} Schedule"
+        base_name = "Schedule"
 
         super().__init__(coordinator, config_entry, child_guid, base_name)
 

--- a/custom_components/firefly_cloud/calendar.py
+++ b/custom_components/firefly_cloud/calendar.py
@@ -11,7 +11,6 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_CHILDREN_GUIDS,
-    CONF_SCHOOL_NAME,
     CONF_USER_GUID,
     DOMAIN,
 )

--- a/custom_components/firefly_cloud/const.py
+++ b/custom_components/firefly_cloud/const.py
@@ -2,6 +2,7 @@
 
 import datetime
 from datetime import timedelta
+from typing import TypedDict
 
 DOMAIN = "firefly_cloud"
 
@@ -37,8 +38,18 @@ SENSOR_OVERDUE_TASKS = "overdue_tasks"
 SENSOR_CURRENT_CLASS = "current_class"
 SENSOR_NEXT_CLASS = "next_class"
 
+
+class SensorConfig(TypedDict):
+    """Type definition for sensor configuration."""
+
+    name: str
+    icon: str
+    unit: str | None
+    device_class: str | None
+
+
 # Sensor configurations
-SENSOR_TYPES = {
+SENSOR_TYPES: dict[str, SensorConfig] = {
     SENSOR_UPCOMING_TASKS: {
         "name": "Upcoming Tasks",
         "icon": "mdi:clipboard-text",

--- a/custom_components/firefly_cloud/sensor.py
+++ b/custom_components/firefly_cloud/sensor.py
@@ -69,7 +69,7 @@ class FireflySensor(FireflyBaseEntity, SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         sensor_config = SENSOR_TYPES[sensor_type]
-        base_name = sensor_config['name']
+        base_name = sensor_config["name"]
 
         super().__init__(coordinator, config_entry, child_guid, base_name)
 

--- a/custom_components/firefly_cloud/sensor.py
+++ b/custom_components/firefly_cloud/sensor.py
@@ -11,7 +11,6 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_CHILDREN_GUIDS,
-    CONF_SCHOOL_NAME,
     CONF_SHOW_CLASS_TIMES,
     CONF_USER_GUID,
     DEFAULT_SHOW_CLASS_TIMES,

--- a/custom_components/firefly_cloud/sensor.py
+++ b/custom_components/firefly_cloud/sensor.py
@@ -68,9 +68,8 @@ class FireflySensor(FireflyBaseEntity, SensorEntity):
         child_guid: str,
     ) -> None:
         """Initialize the sensor."""
-        school_name = config_entry.data.get(CONF_SCHOOL_NAME, "firefly")
         sensor_config = SENSOR_TYPES[sensor_type]
-        base_name = f"{school_name} {sensor_config['name']}"
+        base_name = sensor_config['name']
 
         super().__init__(coordinator, config_entry, child_guid, base_name)
 

--- a/custom_components/firefly_cloud/todo.py
+++ b/custom_components/firefly_cloud/todo.py
@@ -63,8 +63,7 @@ class FireflyTodoListEntity(FireflyBaseEntity, TodoListEntity):
         child_guid: str,
     ) -> None:
         """Initialize the todo list entity."""
-        school_name = config_entry.data.get(CONF_SCHOOL_NAME, "firefly")
-        base_name = f"{school_name} Tasks"
+        base_name = "Tasks"
 
         super().__init__(coordinator, config_entry, child_guid, base_name)
 

--- a/custom_components/firefly_cloud/todo.py
+++ b/custom_components/firefly_cloud/todo.py
@@ -17,7 +17,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
     CONF_CHILDREN_GUIDS,
-    CONF_SCHOOL_NAME,
     CONF_USER_GUID,
     DOMAIN,
 )

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -77,7 +77,7 @@ class TestFireflyTodoListEntity:
         assert todo_entity._child_guid == "child123"
         assert todo_entity._config_entry == mock_config_entry
         assert todo_entity.unique_id == "test_entry_todo_child123"
-        assert "Test School Tasks" in todo_entity._base_name
+        assert "Tasks" == todo_entity._base_name
         assert todo_entity.icon == "mdi:clipboard-check"
 
         # Test device info
@@ -92,7 +92,7 @@ class TestFireflyTodoListEntity:
         """Test entity name with child data available."""
         name = todo_entity.name
         assert "Test Child" in name
-        assert "Test School Tasks" in name
+        assert name == "Tasks (Test Child)"
 
     def test_name_without_child_data(self, todo_entity, mock_coordinator):
         """Test entity name without child data."""


### PR DESCRIPTION
Technically a breaking change, but as we haven't hit 1.0 yet... it's okay.