### PR TITLE
ci: use PAT for release-please to trigger workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
## Summary
- Update release-please workflow to use `RELEASE_PLEASE_TOKEN` instead of `GITHUB_TOKEN`
- This allows release PRs to trigger test workflows (GitHub blocks workflows triggered by `GITHUB_TOKEN` to prevent infinite loops)

## Changes
- Changed `token` parameter in release-please workflow from `secrets.GITHUB_TOKEN` to `secrets.RELEASE_PLEASE_TOKEN`

## Setup Required
A repository secret `RELEASE_PLEASE_TOKEN` must be added with a Personal Access Token that has `repo` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)