### PR TITLE
refactor: remove task classification guessing

### DIFF
--- a/custom_components/firefly_cloud/sensor.py
+++ b/custom_components/firefly_cloud/sensor.py
@@ -170,7 +170,6 @@ class FireflySensor(FireflyBaseEntity, SensorEntity):
                     "subject": task.get("subject", "Unknown"),
                     "due_date": task["due_date"].isoformat() if task["due_date"] else None,
                     "due_date_formatted": (task["due_date"].strftime("%A, %d %B %Y") if task["due_date"] else None),
-                    "task_type": task["task_type"],
                     "days_until_due": ((task["due_date"].date() - now.date()).days if task["due_date"] else None),
                     "setter": task["setter"],
                 }
@@ -192,17 +191,11 @@ class FireflySensor(FireflyBaseEntity, SensorEntity):
         """Get attributes for tasks due today sensor."""
         tasks = child_data.get("tasks", {}).get("due_today", [])
 
-        # Categorize by urgency/type
-        urgent_tasks = [
-            task for task in tasks if task["task_type"] in ["test", "project"] or "urgent" in task["title"].lower()
-        ]
-
         return {
             "tasks": [
                 {
                     "title": task["title"],
                     "subject": task.get("subject", "Unknown"),
-                    "task_type": task["task_type"],
                     "setter": task["setter"],
                     "description": (
                         task["description"][:100] + "..."
@@ -212,17 +205,6 @@ class FireflySensor(FireflyBaseEntity, SensorEntity):
                 }
                 for task in tasks
             ],
-            "urgent_tasks": [
-                {
-                    "title": task["title"],
-                    "subject": task.get("subject", "Unknown"),
-                    "task_type": task["task_type"],
-                }
-                for task in urgent_tasks
-            ],
-            "homework_count": len([t for t in tasks if t["task_type"] == "homework"]),
-            "project_count": len([t for t in tasks if t["task_type"] == "project"]),
-            "test_count": len([t for t in tasks if t["task_type"] == "test"]),
         }
 
     def _get_overdue_tasks_attributes(self, child_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -239,7 +221,6 @@ class FireflySensor(FireflyBaseEntity, SensorEntity):
                     "subject": task.get("subject", "Unknown"),
                     "due_date": task["due_date"].isoformat() if task["due_date"] else None,
                     "due_date_formatted": (task["due_date"].strftime("%A, %d %B %Y") if task["due_date"] else None),
-                    "task_type": task["task_type"],
                     "days_overdue": ((now.date() - task["due_date"].date()).days if task["due_date"] else 0),
                     "setter": task["setter"],
                     "description": (

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 from homeassistant.core import HomeAssistant
@@ -1203,80 +1203,6 @@ async def test_coordinator_get_events_for_day_with_data(hass: HomeAssistant, moc
     tomorrow_events = coordinator.get_events_for_day(tomorrow)
     assert len(tomorrow_events) == 1
     assert tomorrow_events[0]["subject"] == "Tomorrow's Event"
-
-
-@pytest.mark.asyncio
-async def test_coordinator_get_tasks_by_subject_no_data(hass: HomeAssistant, mock_api):
-    """Test get_tasks_by_subject with no data."""
-    coordinator = FireflyUpdateCoordinator(
-        hass=hass,
-        api=mock_api,
-        task_lookahead_days=7,
-    )
-
-    # Test with no data
-    result = coordinator.get_tasks_by_subject()
-    assert result == {}
-
-
-@pytest.mark.asyncio
-async def test_coordinator_get_tasks_by_subject_with_data(hass: HomeAssistant, mock_api):
-    """Test get_tasks_by_subject with actual data."""
-    coordinator = FireflyUpdateCoordinator(
-        hass=hass,
-        api=mock_api,
-        task_lookahead_days=7,
-    )
-
-    # Mock data structure
-    coordinator.data = {
-        "tasks": {
-            "upcoming": [
-                {"subject": "Math", "title": "Math Homework"},
-                {"subject": "Science", "title": "Lab Report"},
-                {"subject": "Math", "title": "Math Test"},
-            ]
-        }
-    }
-
-    result = coordinator.get_tasks_by_subject()
-
-    assert "Math" in result
-    assert "Science" in result
-    assert len(result["Math"]) == 2
-    assert len(result["Science"]) == 1
-    assert result["Math"][0]["title"] == "Math Homework"
-    assert result["Math"][1]["title"] == "Math Test"
-    assert result["Science"][0]["title"] == "Lab Report"
-
-
-@pytest.mark.asyncio
-async def test_coordinator_get_special_requirements_today(hass: HomeAssistant, mock_api):
-    """Test get_special_requirements_today."""
-    coordinator = FireflyUpdateCoordinator(
-        hass=hass,
-        api=mock_api,
-        task_lookahead_days=7,
-    )
-
-    now = datetime.now()
-
-    # Mock today's events with special requirements
-    events_with_requirements = [
-        {"start": now, "subject": "PE", "description": None},
-        {"start": now, "subject": "Art", "description": "Bring special equipment for painting"},
-        {"start": now, "subject": "Games", "description": "Sports kit required for outdoor activities"},
-    ]
-
-    # Patch get_events_for_day to return our mock events
-    with patch.object(coordinator, "get_events_for_day", return_value=events_with_requirements):
-        requirements = coordinator.get_special_requirements_today()
-
-        assert "Sports kit required" in requirements
-        assert "Special equipment for Art" in requirements
-        # Should deduplicate sports kit requirement
-        sports_kit_count = sum(1 for req in requirements if "Sports kit required" in req)
-        assert sports_kit_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -452,9 +452,6 @@ async def test_sensor_attributes_tasks_due_today(mock_coordinator, mock_config_e
 
     attributes = sensor.extra_state_attributes
     assert "tasks" in attributes
-    assert "homework_count" in attributes
-    assert "project_count" in attributes
-    assert "test_count" in attributes
     assert "last_updated" in attributes
 
     # Check task details


### PR DESCRIPTION
## Summary
- Removed all logic that guesses or infers information not provided by the Firefly API
- Removed task type classification based on keywords in titles/descriptions
- Removed "urgent tasks" classification
- Removed special requirements detection (PE kit, equipment)
- Removed unused helper methods

## Changes

### Coordinator
- Removed `_determine_task_type()` method that guessed task types from keywords
- Removed `task_type` field from processed task data
- Removed `get_special_requirements_today()` that guessed PE kit needs from event titles
- Removed unused `get_tasks_by_subject()` helper method

### Sensors
- Removed `task_type` from all task attributes (upcoming, due today, overdue)
- Removed `urgent_tasks` classification based on title keywords
- Removed `homework_count`, `project_count`, `test_count` attributes

### Tests
- Removed tests for deleted methods
- Removed unused `patch` import
- Updated assertions to match new attribute structure

## Rationale
The Firefly API doesn't provide task type or classification information. We shouldn't invent data that's not in the API. Task and event data now only includes factual information directly from the API.

## Test plan
- [x] All 261 tests pass
- [x] >95% test coverage maintained (95%)
- [x] Linting passes (black, flake8, mypy, pylint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)