### PR TITLE
ci: add Python 3.14 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Adds `"3.14"` to the test matrix in `.github/workflows/test.yml`, so the suite runs on Python 3.11–3.14.

## Why this is low-risk here
The integration already pins modern Home Assistant for Python ≥3.13 (`homeassistant>=2025.12.0`), so 3.14 resolves to the same HA (2026.6.4) it already tests against on 3.13 — no dependency change needed.

## Verification
Run locally on Python 3.14 (Homebrew):
- Deps install cleanly — HA 2026.6.4, orjson 3.11.9 (cp314 wheel).
- `pytest tests/` → **283 passed, 95.63% coverage**.

CI will confirm the new `Test Python 3.14` context here.

## Follow-up
Once `Test Python 3.14` is green, it can be added to the repo's branch ruleset required checks (currently 3.11/3.12/3.13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)